### PR TITLE
Add digital IO utility functions and example

### DIFF
--- a/examples/digital.rs
+++ b/examples/digital.rs
@@ -1,0 +1,47 @@
+extern crate bela;
+
+use bela::*;
+
+struct State {
+    idx: usize,
+}
+
+fn main() {
+    go().unwrap();
+}
+
+fn go() -> Result<(), error::Error> {
+    let mut setup = |context: &mut Context, _user_data: &mut State| -> Result<(), error::Error> {
+        println!("Setting up");
+        context.pin_mode(0, 0, DigitalDirection::OUTPUT);
+        Ok(())
+    };
+
+    let mut cleanup = |_context: &mut Context, _user_data: &mut State| {
+        println!("Cleaning up");
+    };
+
+    // Generates impulses on the first digital port every 100ms for 10ms
+    let mut render = |context: &mut Context, state: &mut State| {
+        let tenms_in_frames = (context.digital_sample_rate() / 100.) as usize;
+        let hundreadms_in_frames = (tenms_in_frames * 10) as usize;
+        for f in 0..context.digital_frames() {
+            let v = if state.idx < tenms_in_frames { 1 } else { 0 };
+            context.digital_write_once(f, 0, v);
+            state.idx += 1;
+            if state.idx > hundreadms_in_frames {
+                state.idx = 0;
+            }
+        }
+    };
+
+    let state = State {
+        idx: 0,
+    };
+
+    let user_data = AppData::new(state, &mut render, Some(&mut setup), Some(&mut cleanup));
+
+    let mut bela_app = Bela::new(user_data);
+    let mut settings = InitSettings::default();
+    bela_app.run(&mut settings)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,6 @@ impl Context {
     /// Access the analog input slice
     pub fn analog_in(&self) -> &[f32] {
         unsafe {
-            let context = self.context_ptr();
             let n_frames = (*self.context).analogFrames;
             let n_channels = (*self.context).analogInChannels;
             let analog_in_ptr = (*self.context).analogIn as *mut f32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,12 +282,12 @@ impl Context {
     ///
     /// Mutably borrows self so that (hopefully) we do not have multiple mutable
     /// pointers to the digital buffer available simultaneously.
-    pub fn digital_out(&mut self) -> &mut [f32] {
+    pub fn digital(&mut self) -> &mut [u32] {
         unsafe {
             let context = self.context_ptr();
             let n_frames = (*context).digitalFrames;
             let n_channels = (*context).digitalChannels;
-            let digital_ptr = (*context).digital as *mut f32;
+            let digital_ptr = (*context).digital as *mut u32;
             slice::from_raw_parts_mut(digital_ptr, (n_frames * n_channels) as usize)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,11 @@ use std::marker::PhantomData;
 
 pub mod error;
 
+pub enum DigitalDirection {
+    INPUT,
+    OUTPUT,
+}
+
 /// The `Bela` struct is essentially built to ensure that the type parameter
 /// `<T>` is consistent across all invocations of the setup, render, and cleanup
 /// functions. This is because `<T>` is the `UserData` of the original Bela
@@ -419,6 +424,54 @@ impl Context {
     pub fn flags(&self) -> u32 {
         unsafe {
             (*self.context).flags
+        }
+    }
+
+    // Returns the value of a given digital input at the given frame number
+    pub fn digital_read(&mut self, frame: usize, channel: usize) -> u32 {
+        let digital = self.digital();
+        (digital[frame] >> (channel + 16)) & 1
+    }
+
+    // Sets a given digital output channel to a value for the current frame and all subsequent frames
+    pub fn digital_write(&mut self, frame: usize, channel: usize, value: usize) {
+        let digital = self.digital();
+        for i in frame..digital.len() {
+            if value != 0 {
+                digital[i] |= 1 << (channel + 16);
+            } else {
+                digital[i] &= !(1 << (channel + 16));
+            }
+        }
+    }
+
+    // Sets a given digital output channel to a value for the current frame only
+    pub fn digital_write_once(&mut self, frame: usize, channel: usize, value: usize) {
+        let digital = self.digital();
+        if value != 0 {
+            digital[frame] |= 1 << (channel + 16);
+        } else {
+            digital[frame] &= !(1 << (channel + 16));
+        }
+    }
+
+    // Sets the direction of a digital pin for the current frame and all subsequent frames
+    pub fn pin_mode(&mut self, frame: usize, channel: usize, mode: DigitalDirection) {
+        let digital = self.digital();
+        for i in frame..digital.len() {
+            match mode {
+                DigitalDirection::INPUT => { digital[i] |= 1 << channel; }
+                DigitalDirection::OUTPUT => { digital[i] &= !(1 << channel); }
+            }
+        }
+    }
+
+    // Sets the direction of a digital pin for the current frame only
+    pub fn pin_mode_once(&mut self, frame: usize, channel: usize, mode: DigitalDirection) {
+        let digital = self.digital();
+        match mode {
+            DigitalDirection::INPUT => { digital[frame] |= 1 << channel; }
+            DigitalDirection::OUTPUT => { digital[frame] &= !(1 << channel); }
         }
     }
 }


### PR DESCRIPTION
Unlike audio or analog IO, it's really unpractical to use the buffer directly for digital IO, so I think it's worth it to provide those utility method.

They are ported straight from `include/Utilities.h` from the Bela repo, an example is provided.

Also include a bug fix (wrong type for the `digital` buffer) and a warning fix (unused variable).