### PR TITLE
Updates for Bela 0.3.8b and Rust 1.52.0/1.53.0

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
+linker = "arm-none-linux-gnueabihf-gcc"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
+.vscode
 /target
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ sample = { package = "dasp", version = "0.11.0", features = [ "signal", "slice" 
 
 [dependencies.bela-sys]
 git = "https://github.com/andrewcsmith/bela-sys.git"
+
+[features]
+static = [ "bela-sys/static" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ authors = ["Andrew C. Smith <andrewchristophersmith@gmail.com>"]
 [dependencies]
 libc = "0.2"
 nix = "0.10"
-sample = "0.9"
+
+[dev-dependencies]
+sample = { package = "dasp", version = "0.11.0", features = [ "signal", "slice" ] }
 
 [dependencies.bela-sys]
 git = "https://github.com/andrewcsmith/bela-sys.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew C. Smith <andrewchristophersmith@gmail.com>"]
 
 [dependencies]
 libc = "0.2"
-nix = "0.10"
+nix = "0.21"
 
 [dev-dependencies]
 sample = { package = "dasp", version = "0.11.0", features = [ "signal", "slice" ] }

--- a/examples/auxiliary_task.rs
+++ b/examples/auxiliary_task.rs
@@ -15,16 +15,14 @@ struct PrintTask<F> {
 }
 
 impl<F> Auxiliary for PrintTask<F>
-where F: FnMut(&mut String),
-      for<'r> F: FnMut(&'r mut String)
+where
+    F: FnMut(&mut String),
+    for<'r> F: FnMut(&'r mut String),
 {
     type Args = String;
 
     fn destructure(&mut self) -> (&mut dyn FnMut(&mut String), &mut Self::Args) {
-        let PrintTask {
-            callback,
-            args,
-        } = self;
+        let PrintTask { callback, args } = self;
 
         (callback, args)
     }
@@ -32,7 +30,7 @@ where F: FnMut(&mut String),
 
 struct MyData<'a> {
     frame_index: usize,
-    tasks: Vec<CreatedTask<'a>>
+    tasks: Vec<CreatedTask<'a>>,
 }
 
 type BelaApp<'a> = Bela<AppData<'a, MyData<'a>>>;
@@ -64,8 +62,12 @@ fn go() -> Result<(), error::Error> {
 
     let mut setup = |_context: &mut Context, user_data: &mut MyData| -> Result<(), error::Error> {
         println!("Setting up");
-        user_data.tasks.push(unsafe { BelaApp::create_auxiliary_task(&mut boxed, 10, "printing_stuff") });
-        user_data.tasks.push(unsafe { BelaApp::create_auxiliary_task(&mut another_print_task, 10, "printing_more_stuff") });
+        user_data
+            .tasks
+            .push(unsafe { BelaApp::create_auxiliary_task(&mut boxed, 10, "printing_stuff") });
+        user_data.tasks.push(unsafe {
+            BelaApp::create_auxiliary_task(&mut another_print_task, 10, "printing_more_stuff")
+        });
         Ok(())
     };
 

--- a/examples/auxiliary_task.rs
+++ b/examples/auxiliary_task.rs
@@ -64,8 +64,8 @@ fn go() -> Result<(), error::Error> {
 
     let mut setup = |_context: &mut Context, user_data: &mut MyData| -> Result<(), error::Error> {
         println!("Setting up");
-        user_data.tasks.push(BelaApp::create_auxiliary_task(&mut boxed, 10, "printing_stuff"));
-        user_data.tasks.push(BelaApp::create_auxiliary_task(&mut another_print_task, 10, "printing_more_stuff"));
+        user_data.tasks.push(unsafe { BelaApp::create_auxiliary_task(&mut boxed, 10, "printing_stuff") });
+        user_data.tasks.push(unsafe { BelaApp::create_auxiliary_task(&mut another_print_task, 10, "printing_more_stuff") });
         Ok(())
     };
 

--- a/examples/auxiliary_task.rs
+++ b/examples/auxiliary_task.rs
@@ -1,8 +1,8 @@
 //! Produces a sine wave while printing "this is a string" repeatedly,
 //! appending "LOL" to every iteration.
-//! 
+//!
 //! There's an example here for both the stack-allocated and a Boxed closure.
-//! 
+//!
 extern crate bela;
 extern crate sample;
 
@@ -20,7 +20,7 @@ where F: FnMut(&mut String),
 {
     type Args = String;
 
-    fn destructure(&mut self) -> (&mut FnMut(&mut String), &mut Self::Args) {
+    fn destructure(&mut self) -> (&mut dyn FnMut(&mut String), &mut Self::Args) {
         let PrintTask {
             callback,
             args,
@@ -76,7 +76,7 @@ fn go() -> Result<(), error::Error> {
     let mut render = |_context: &mut Context, user_data: &mut MyData| {
         if user_data.frame_index % 1024 == 0 {
             for task in user_data.tasks.iter() {
-                BelaApp::schedule_auxiliary_task(task);
+                BelaApp::schedule_auxiliary_task(task).unwrap();
             }
         }
 

--- a/examples/digital.rs
+++ b/examples/digital.rs
@@ -35,9 +35,7 @@ fn go() -> Result<(), error::Error> {
         }
     };
 
-    let state = State {
-        idx: 0,
-    };
+    let state = State { idx: 0 };
 
     let user_data = AppData::new(state, &mut render, Some(&mut setup), Some(&mut cleanup));
 

--- a/examples/digital.rs
+++ b/examples/digital.rs
@@ -26,7 +26,7 @@ fn go() -> Result<(), error::Error> {
         let tenms_in_frames = (context.digital_sample_rate() / 100.) as usize;
         let hundreadms_in_frames = (tenms_in_frames * 10) as usize;
         for f in 0..context.digital_frames() {
-            let v = if state.idx < tenms_in_frames { 1 } else { 0 };
+            let v = state.idx < tenms_in_frames;
             context.digital_write_once(f, 0, v);
             state.idx += 1;
             if state.idx > hundreadms_in_frames {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -33,9 +33,7 @@ fn go() -> Result<(), error::Error> {
         }
     };
 
-    let phasor = Phasor {
-        idx: 0,
-    };
+    let phasor = Phasor { idx: 0 };
 
     let user_data = AppData::new(phasor, &mut render, Some(&mut setup), Some(&mut cleanup));
 

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -1,31 +1,35 @@
 extern crate bela;
 extern crate sample;
 
-use std::{thread, time};
 use bela::*;
 use sample::Signal;
+use std::{thread, time};
 
 fn main() {
     go().unwrap();
 }
 
 fn go() -> Result<(), error::Error> {
-    let mut setup = |_context: &mut Context, _user_data: &mut Option<Box<dyn Signal<Frame=f64>>>| -> Result<(), error::Error> {
+    let mut setup = |_context: &mut Context,
+                     _user_data: &mut Option<Box<dyn Signal<Frame = f64>>>|
+     -> Result<(), error::Error> {
         println!("Setting up");
         Ok(())
     };
 
-    let mut cleanup = |_context: &mut Context, _user_data: &mut Option<Box<dyn Signal<Frame=f64>>>| {
-        println!("Cleaning up");
-    };
+    let mut cleanup =
+        |_context: &mut Context, _user_data: &mut Option<Box<dyn Signal<Frame = f64>>>| {
+            println!("Cleaning up");
+        };
 
     // Generates a sine wave with the period of whatever the audio frame
     // size is.
-    let mut render = |context: &mut Context, synth: &mut Option<Box<dyn Signal<Frame=f64>>>| {
+    let mut render = |context: &mut Context, synth: &mut Option<Box<dyn Signal<Frame = f64>>>| {
         let audio_out_channels = context.audio_out_channels();
         assert_eq!(audio_out_channels, 2);
         let audio_out = context.audio_out();
-        let audio_out_frames: &mut [[f32; 2]] = sample::slice::to_frame_slice_mut(audio_out).unwrap();
+        let audio_out_frames: &mut [[f32; 2]] =
+            sample::slice::to_frame_slice_mut(audio_out).unwrap();
 
         for frame in audio_out_frames.iter_mut() {
             for samp in frame.iter_mut() {
@@ -35,11 +39,9 @@ fn go() -> Result<(), error::Error> {
         }
     };
 
-    let sig = sample::signal::rate(44_100.0)
-                .const_hz(440.0)
-                .sine();
+    let sig = sample::signal::rate(44_100.0).const_hz(440.0).sine();
 
-    let synth: Option<Box<dyn Signal<Frame=f64>>> = Some(Box::new(sig));
+    let synth: Option<Box<dyn Signal<Frame = f64>>> = Some(Box::new(sig));
 
     let user_data = AppData::new(synth, &mut render, Some(&mut setup), Some(&mut cleanup));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,16 +219,17 @@ impl<'a, T: UserData<'a> + 'a> Bela<T> {
     /// Takes a _mutable reference_ to the task, because we must be ensured that
     /// the task is unique and that it does not move.
     ///
+    /// # Safety
     /// I highly recommend ONLY USING STACK-ALLOCATED CLOSURES AS TASKS. This
     /// particular implementation is wildly unsafe, but if you use a stack
     /// closure it _should_ be possible to avoid a segfault. See the
     /// auxiliary_task example for a demo.
-    pub fn create_auxiliary_task<'b, 'c, A: 'b>(task: &'c mut A, priority: i32, name: &'static str) -> CreatedTask<'b>
+    pub unsafe fn create_auxiliary_task<'b, 'c, A: 'b>(task: &'c mut A, priority: i32, name: &'static str) -> CreatedTask<'b>
     where A: Auxiliary
     {
         let task_ptr = task as *const _ as *mut std::os::raw::c_void;
 
-        let aux_task = unsafe {
+        let aux_task = {
             bela_sys::Bela_createAuxiliaryTask(
                 Some(auxiliary_task_trampoline::<A>),
                 priority,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,15 +507,20 @@ impl Context {
 pub trait UserData<'a> {
     type Data;
 
-    fn render_fn(&mut self, &mut Context);
-    fn set_render_fn(&mut self, &'a mut dyn FnMut(&mut Context, &mut Self::Data));
-    fn setup_fn(&mut self, &mut Context) -> Result<(), error::Error>;
+    fn render_fn(&mut self, context: &mut Context);
+    fn set_render_fn(&mut self, render_fn: &'a mut dyn FnMut(&mut Context, &mut Self::Data));
+    fn setup_fn(&mut self, context: &mut Context) -> Result<(), error::Error>;
     fn set_setup_fn(
         &mut self,
-        Option<&'a mut dyn FnMut(&mut Context, &mut Self::Data) -> Result<(), error::Error>>,
+        setup_fn: Option<
+            &'a mut dyn FnMut(&mut Context, &mut Self::Data) -> Result<(), error::Error>,
+        >,
     );
-    fn cleanup_fn(&mut self, &mut Context);
-    fn set_cleanup_fn(&mut self, Option<&'a mut dyn FnMut(&mut Context, &mut Self::Data)>);
+    fn cleanup_fn(&mut self, context: &mut Context);
+    fn set_cleanup_fn(
+        &mut self,
+        cleanup_fn: Option<&'a mut dyn FnMut(&mut Context, &mut Self::Data)>,
+    );
 }
 
 pub struct AppData<'a, D: 'a> {


### PR DESCRIPTION
This is a companion PR to https://github.com/andrewcsmith/bela-sys/pull/1. This (also admittedly large) set of patches updates `bela-rs` to

- Work with current Rust and current dependent crate versions
- Work with current Bela versions (different APIs/struct definitions, removed use of deprecated variables / APIs etc.)
- Work with the new ARM linker name (on Windows at least)

Additionally, I tried to make the code more idiomatic, primarily in commits https://github.com/andrewcsmith/bela-rs/commit/6a6e174c50d4dc4c00e0a555036c7dabfe81d5b4, https://github.com/andrewcsmith/bela-rs/commit/c556484e13c7fcfe4481bbea0eefbd8d0ad1d9ca, https://github.com/andrewcsmith/bela-rs/commit/306cc3a61aef639785488e43f5f874f1bd21f6c4, and https://github.com/andrewcsmith/bela-rs/commit/0f4d3df2a5749adfbc23922fa43f3070cfc95171