### PR TITLE
Redesign of create_auxiliary_task for improved safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["Andrew C. Smith <andrewchristophersmith@gmail.com>"]
 
 [dependencies]
-libc = "0.2"
-nix = "0.21"
 
 [dev-dependencies]
 sample = { package = "dasp", version = "0.11.0", features = [ "signal", "slice" ] }

--- a/examples/auxiliary_task.rs
+++ b/examples/auxiliary_task.rs
@@ -8,66 +8,38 @@ extern crate sample;
 
 use bela::*;
 
-#[derive(Clone)]
-struct PrintTask<F> {
-    callback: F,
-    args: String,
-}
-
-impl<F> Auxiliary for PrintTask<F>
-where
-    F: FnMut(&mut String),
-    for<'r> F: FnMut(&'r mut String),
-{
-    type Args = String;
-
-    fn destructure(&mut self) -> (&mut dyn FnMut(&mut String), &mut Self::Args) {
-        let PrintTask { callback, args } = self;
-
-        (callback, args)
-    }
-}
-
-struct MyData<'a> {
+struct MyData {
     frame_index: usize,
-    tasks: Vec<CreatedTask<'a>>,
+    tasks: Vec<CreatedTask>,
 }
 
-type BelaApp<'a> = Bela<AppData<'a, MyData<'a>>>;
+type BelaApp<'a> = Bela<AppData<'a, MyData>>;
 
 fn main() {
     go().unwrap();
 }
 
 fn go() -> Result<(), error::Error> {
-    let what_to_print = "this is a string".to_string();
-    let print_task = PrintTask {
-        callback: |args: &mut String| {
-            args.push_str("LOL");
-            println!("{}", args);
-        },
-        args: what_to_print,
-    };
-
-    let more_to_print = "this is another string".to_string();
-    let mut another_print_task = PrintTask {
-        callback: |args: &mut String| {
-            args.push_str("LOL");
-            println!("{}", args);
-        },
-        args: more_to_print,
-    };
-
-    let mut boxed = Box::new(print_task);
-
     let mut setup = |_context: &mut Context, user_data: &mut MyData| -> Result<(), error::Error> {
         println!("Setting up");
-        user_data
-            .tasks
-            .push(unsafe { BelaApp::create_auxiliary_task(&mut boxed, 10, "printing_stuff") });
-        user_data.tasks.push(unsafe {
-            BelaApp::create_auxiliary_task(&mut another_print_task, 10, "printing_more_stuff")
+        let print_task = Box::new(|| {
+            println!("this is a string");
         });
+
+        let another_print_task = Box::new(|| {
+            println!("this is another string");
+        });
+
+        user_data.tasks.push(BelaApp::create_auxiliary_task(
+            print_task,
+            10,
+            "printing_stuff",
+        ));
+        user_data.tasks.push(BelaApp::create_auxiliary_task(
+            another_print_task,
+            10,
+            "printing_more_stuff",
+        ));
         Ok(())
     };
 

--- a/examples/auxiliary_task.rs
+++ b/examples/auxiliary_task.rs
@@ -33,12 +33,12 @@ fn go() -> Result<(), error::Error> {
         user_data.tasks.push(BelaApp::create_auxiliary_task(
             print_task,
             10,
-            "printing_stuff",
+            &std::ffi::CString::new("printing_stuff").unwrap(),
         ));
         user_data.tasks.push(BelaApp::create_auxiliary_task(
             another_print_task,
             10,
-            "printing_more_stuff",
+            &std::ffi::CStr::from_bytes_with_nul(b"printing_more_stuff\0").unwrap(),
         ));
         Ok(())
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ impl<'a, T: UserData<'a> + 'a> Bela<T> {
     pub fn create_auxiliary_task<Auxiliary>(
         task: Box<Auxiliary>,
         priority: i32,
-        name: &str,
+        name: &std::ffi::CStr,
     ) -> CreatedTask
     where
         Auxiliary: FnMut() + Send + 'static,
@@ -217,7 +217,7 @@ impl<'a, T: UserData<'a> + 'a> Bela<T> {
             bela_sys::Bela_createAuxiliaryTask(
                 Some(auxiliary_task_trampoline::<Auxiliary>),
                 priority,
-                name.as_bytes().as_ptr(),
+                name.as_ptr(),
                 task_ptr,
             )
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 extern crate bela_sys;
-extern crate libc;
-extern crate nix;
 
 use bela_sys::{BelaContext, BelaInitSettings};
 use std::convert::TryInto;


### PR DESCRIPTION
Fixes #3 while simplifying the auxiliary task API. No more need to implement the `Auxiliary`, just use a boxed closure instead.

Two points that are still not ideal:

1. The boxed closures are leaked, as Bela offers no API to join & unregister auxiliary tasks. This would have to be fixed upstream.
2. According to Bela documentation, the `name` given to a task must be globally unique across all Xenomai processes, i.e., even unique within the program is insufficient. Should a name be randomly generated instead? Or a GUID appended?